### PR TITLE
Issue#32 moar mutations

### DIFF
--- a/NeuralFish.Tests/Cortex.fs
+++ b/NeuralFish.Tests/Cortex.fs
@@ -62,7 +62,8 @@ let ``Cortex should be able to synchronize neural activity`` () =
 
   let cortex = neuralNetwork |> createCortex
 
-  ThinkAndAct |> cortex.PostAndReply
+  let thinkCycleState = ThinkAndAct |> cortex.PostAndReply
+  thinkCycleState |> should equal ThinkCycleFinished
   WaitForData
   |> testHookMailbox.PostAndReply
   |> (should equal 110.0)
@@ -72,3 +73,68 @@ let ``Cortex should be able to synchronize neural activity`` () =
   |> ignore
 
   Die |> testHookMailbox.PostAndReply
+
+[<Fact>]
+let ``Cortex should shutdown a think cycle if time exceeds timeout value`` () =
+  let mutable neuralNetworkProcessedThinkCycle = false
+  let testHook = (fun _ -> neuralNetworkProcessedThinkCycle <- true)
+  let getNodeId = getNumberGenerator()
+  let syncFunctionId = 9001
+  let syncFunction =
+    let data =
+      [1.0; 1.0; 1.0; 1.0; 1.0]
+      |> List.toSeq
+    fakeDataGenerator([data])
+  let outputHookId = 9000
+  let activationFunctionId = 777
+
+  let actuatorId = getNodeId()
+  let actuator =
+    let layer = 3
+    createActuator actuatorId layer testHook outputHookId
+    |> createNeuronInstance
+
+  let neuronId = getNodeId()
+  let neuron =
+    let activationFunction = id
+    let bias = 10.0
+    let layer = 2
+    createNeuron neuronId layer activationFunction activationFunctionId bias NoLearning
+    |> createNeuronInstance
+
+  let sensorId = getNodeId()
+  let sensor =
+    createSensor sensorId syncFunction syncFunctionId 1
+    |> createNeuronInstance
+
+  //This will prevent the NN from working
+  //neuron |> connectNodeToActuator actuator
+
+  let weights =
+    [
+      20.0
+      20.0
+      20.0
+      20.0
+      20.0
+    ] |> List.toSeq
+  sensor |> connectSensorToNode neuron weights
+
+  let neuralNetwork = 
+    Map.empty
+    |> addNeuronToMap actuator
+    |> addNeuronToMap neuron
+    |> addNeuronToMap sensor
+
+  let cortex = neuralNetwork |> createCortex
+
+  let thinkCycleState = ThinkAndAct |> cortex.PostAndReply
+  thinkCycleState |> should equal ThinkCycleIncomplete
+
+  neuralNetworkProcessedThinkCycle
+  |> should equal false
+
+  KillCortex
+  |> cortex.PostAndReply
+  |> ignore
+

--- a/NeuralFish.Tests/EvolutionChamber.fs
+++ b/NeuralFish.Tests/EvolutionChamber.fs
@@ -250,7 +250,7 @@ let ``RemoveBias mutation should remove a bias to a neuron that has some bias`` 
   Die |> testHookMailbox.PostAndReply
 
 [<Fact>]
-let ``MutateWeights mutation should mutate the weights of all outbound connections in a neuron`` () =
+let ``MutateWeights mutation should mutate the weights of some inbound connections in a neuron`` () =
   //Test setup
   let (testHook, testHookMailbox) = getTestHook ()
   let getNodeId = getNumberGenerator()

--- a/NeuralFish.Tests/EvolutionChamber.fs
+++ b/NeuralFish.Tests/EvolutionChamber.fs
@@ -326,6 +326,7 @@ let ``MutateWeights mutation should mutate the weights of some inbound connectio
 
       neuronConnections
       |> Seq.head
+      |> (fun x -> x.Value)
     neuronConnection.Weight
     |> should (equalWithin 0.1) 20.0
 
@@ -376,6 +377,7 @@ let ``MutateWeights mutation should mutate the weights of some inbound connectio
 
       neuron.InboundConnections
       |> Seq.head
+      |> (fun x -> x.Value)
     
     neuronConnection.Weight
     |> should not' (equal 20.0)
@@ -913,6 +915,8 @@ let ``AddSensorLink mutation should add a sensor connection randomly in the neur
     Map.empty
     |> Map.add outputHookId testHook
 
+  let neuronId = neuron |> fst
+  let initialNumberOfNeuronConnections = weights |> List.length
   let nodeRecords =
     let initialNodeRecords =
       Map.empty
@@ -920,6 +924,9 @@ let ``AddSensorLink mutation should add a sensor connection randomly in the neur
       |> addNeuronToMap neuron
       |> addNeuronToMap sensor
       |> constructNodeRecords
+    initialNodeRecords
+    |> Map.find neuronId
+    |> (fun neuronRecord -> neuronRecord.InboundConnections |> Seq.length |> should equal initialNumberOfNeuronConnections)
     let mutations = [AddSensorLink]
     {
       Mutations = mutations
@@ -930,6 +937,10 @@ let ``AddSensorLink mutation should add a sensor connection randomly in the neur
       InfoLog = defaultInfoLog
       NodeRecords = initialNodeRecords
     } |> mutateNeuralNetwork
+
+  nodeRecords
+  |> Map.find neuronId
+  |> (fun neuronRecord -> neuronRecord.InboundConnections |> Seq.length |> should be (greaterThan initialNumberOfNeuronConnections))
 
   [
     sensor
@@ -947,29 +958,6 @@ let ``AddSensorLink mutation should add a sensor connection randomly in the neur
      NodeRecords = nodeRecords
      InfoLog = defaultInfoLog
    } |> constructNeuralNetwork
-
-  let totalSensorOutboundConnections =
-    let sensorId = sensor |> fst
-    let sensorToNeuronConnections =
-      let neuronId = neuron |> fst
-      nodeRecords
-      |> Map.find neuronId
-      |> (fun x -> x.InboundConnections)
-      |> Seq.filter(fun inboundConnection -> inboundConnection.NodeId = sensorId)
-      |> Seq.length
-    let sensorToActuatorConnections =
-      let actuatorId = actuator |> fst
-      nodeRecords
-      |> Map.find actuatorId
-      |> (fun x -> x.InboundConnections)
-      |> Seq.filter(fun inboundConnection -> inboundConnection.NodeId = sensorId)
-      |> Seq.length
-    sensorToNeuronConnections + sensorToActuatorConnections
-
-  let previousWeightLength = weights |> List.length
-
-  totalSensorOutboundConnections
-  |> should be (greaterThan previousWeightLength)
 
   neuralNetwork |> synchronizeNN
   WaitForData
@@ -1095,24 +1083,24 @@ let ``AddActuatorLink mutation should add an actuator connection randomly in the
     let sensorToNeuronConnections =
       neuronRecord
       |> (fun x -> x.InboundConnections)
-      |> Seq.filter(fun inboundConnection -> inboundConnection.NodeId = sensorId)
+      |> Map.filter(fun _ inboundConnection -> inboundConnection.NodeId = sensorId)
       |> Seq.length
     let sensorToActuatorConnections =
       actuatorRecord
       |> (fun x -> x.InboundConnections)
-      |> Seq.filter(fun inboundConnection -> inboundConnection.NodeId = sensorId)
+      |> Map.filter(fun _ inboundConnection -> inboundConnection.NodeId = sensorId)
       |> Seq.length
     sensorToNeuronConnections + sensorToActuatorConnections
   let totalNeuronOutboundConnections =
     let neuronToSensorConnections =
       sensorRecord
       |> (fun x -> x.InboundConnections)
-      |> Seq.filter(fun inboundConnection -> inboundConnection.NodeId = neuronId)
+      |> Map.filter(fun _ inboundConnection -> inboundConnection.NodeId = neuronId)
       |> Seq.length
     let neuronToActuatorConnections =
       actuatorRecord
       |> (fun x -> x.InboundConnections)
-      |> Seq.filter(fun inboundConnection -> inboundConnection.NodeId = neuronId)
+      |> Map.filter(fun _ inboundConnection -> inboundConnection.NodeId = neuronId)
       |> Seq.length
     neuronToSensorConnections + neuronToActuatorConnections
 

--- a/NeuralFish.Tests/Exporter.fs
+++ b/NeuralFish.Tests/Exporter.fs
@@ -14,8 +14,8 @@ let assertNodeRecordsContainsNode (nodeRecords : NodeRecords) (neuronId, (_, liv
   let liveNeuronNodeRecord = GetNodeRecord |> liveNeuron.PostAndReply
   let getNodeRecord nodeId = nodeRecords |> Map.find nodeId
   let assertRecordConnectionIsIdenticalTo (nodeRecordConnections : NodeRecordConnections)  =
-    (fun index (nodeConnection : InactiveNeuronConnection) ->
-      match nodeRecordConnections |> Seq.tryItem index with
+    (fun nodeConnectionId (nodeConnection : InactiveNeuronConnection) ->
+      match nodeRecordConnections |> Map.tryFind nodeConnectionId with
       | None -> "Node record does not have the connection" |> should equal ""
       | Some inactiveConnection -> 
         nodeConnection.NodeId |> should equal inactiveConnection.NodeId
@@ -36,7 +36,7 @@ let assertNodeRecordsContainsNode (nodeRecords : NodeRecords) (neuronId, (_, liv
       nodeRecord.InboundConnections |> Seq.isEmpty |> should equal false
 
       liveNeuronNodeRecord.InboundConnections
-      |> Seq.iteri (assertRecordConnectionIsIdenticalTo nodeRecord.InboundConnections)
+      |> Map.iter (assertRecordConnectionIsIdenticalTo nodeRecord.InboundConnections)
 
     | NodeRecordType.Sensor _ ->
       let nodeRecord =
@@ -51,7 +51,7 @@ let assertNodeRecordsContainsNode (nodeRecords : NodeRecords) (neuronId, (_, liv
       nodeRecord.InboundConnections |> Seq.isEmpty |> should equal true
 
       liveNeuronNodeRecord.InboundConnections
-      |> Seq.iteri (assertRecordConnectionIsIdenticalTo nodeRecord.InboundConnections)
+      |> Map.iter (assertRecordConnectionIsIdenticalTo nodeRecord.InboundConnections)
     | NodeRecordType.Actuator ->
       let nodeRecord =
         liveNeuronNodeRecord.NodeId

--- a/NeuralFish.Tests/Exporter.fs
+++ b/NeuralFish.Tests/Exporter.fs
@@ -523,21 +523,20 @@ let ``Should be able to deconstruct then reconstruct recurrent neural network wi
   neuron_1b |> connectNodeToNeuron neuron_2a 20.0
 
   //Synchronize and Assert!
-  //Since there is a recurrent connection then the output will
   synchronize sensor
   WaitForData
   |> testHookMailbox.PostAndReply
-  |> (should equal 44320.0)
+  |> (should equal 320.0)
 
   synchronize sensor
   WaitForData
   |> testHookMailbox.PostAndReply
-  |> (should equal 1810520.0)
+  |> (should equal 50520.0)
 
   synchronize sensor
   WaitForData
   |> testHookMailbox.PostAndReply
-  |> (should equal 54734520.0)
+  |> (should equal 1934520.0)
 
   let nodeRecords =
     Map.empty
@@ -586,17 +585,17 @@ let ``Should be able to deconstruct then reconstruct recurrent neural network wi
   synchronizeNN neuralNetwork
   WaitForData
   |> testHookMailbox.PostAndReply
-  |> (should equal 44320.0)
+  |> (should equal 320.0)
 
   synchronizeNN neuralNetwork
   WaitForData
   |> testHookMailbox.PostAndReply
-  |> (should equal 1810520.0)
+  |> (should equal 50520.0)
 
   synchronizeNN neuralNetwork
   WaitForData
   |> testHookMailbox.PostAndReply
-  |> (should equal 54734520.0)
+  |> (should equal 1934520.0)
 
   neuralNetwork |> killNeuralNetwork
 

--- a/NeuralFish.Tests/Mutations.fs
+++ b/NeuralFish.Tests/Mutations.fs
@@ -564,13 +564,14 @@ let ``RemoveInboundConnection mutation should remove some neuron connection rand
   let neuronWeight = 1.0
   neuron |> connectNodeToNeuron neuronTwo neuronWeight
   neuron |> connectNodeToNeuron neuronTwo neuronWeight
+  neuron |> connectNodeToNeuron neuronTwo neuronWeight
   neuronTwo |> connectNodeToActuator actuator
 
   //Synchronize and Assert!
   synchronize sensor
   WaitForData
   |> testHookMailbox.PostAndReply
-  |> (should (equalWithin 0.001) 200.0)
+  |> (should (equalWithin 0.001) 300.0)
 
   let activationFunctions : ActivationFunctions =
     Map.empty
@@ -583,7 +584,7 @@ let ``RemoveInboundConnection mutation should remove some neuron connection rand
     |> Map.add outputHookId testHook
 
   let neuronId = neuronTwo |> fst
-  let initialNumberOfNeuronConnections = 2
+  let initialNumberOfNeuronConnections = 3
   let nodeRecords =
     let initialNodeRecords =
       Map.empty
@@ -594,7 +595,7 @@ let ``RemoveInboundConnection mutation should remove some neuron connection rand
       |> constructNodeRecords
     initialNodeRecords
     |> Map.find neuronId
-    |> (fun neuronRecord -> neuronRecord.InboundConnections |> Seq.length |> should equal 2)
+    |> (fun neuronRecord -> neuronRecord.InboundConnections |> Seq.length |> should equal initialNumberOfNeuronConnections)
     let mutations = [RemoveInboundConnection]
     {
       Mutations = mutations
@@ -608,7 +609,7 @@ let ``RemoveInboundConnection mutation should remove some neuron connection rand
 
   nodeRecords
   |> Map.find neuronId
-  |> (fun neuronRecord -> neuronRecord.InboundConnections |> Seq.length |> should equal 1)
+  |> (fun neuronRecord -> neuronRecord.InboundConnections |> Seq.length |> should equal 2)
 
   [
     sensor
@@ -631,7 +632,7 @@ let ``RemoveInboundConnection mutation should remove some neuron connection rand
   neuralNetwork |> synchronizeNN
   WaitForData
   |> testHookMailbox.PostAndReply
-  |> (should (equalWithin 0.001) 100.0)
+  |> (should (equalWithin 0.001) 200.0)
 
   neuralNetwork |> killNeuralNetwork
 
@@ -689,13 +690,14 @@ let ``RemoveOutboundConnection mutation should remove some neuron connection ran
   let neuronWeight = 1.0
   neuron |> connectNodeToNeuron neuronTwo neuronWeight
   neuron |> connectNodeToNeuron neuronTwo neuronWeight
+  neuron |> connectNodeToNeuron neuronTwo neuronWeight
   neuronTwo |> connectNodeToActuator actuator
 
   //Synchronize and Assert!
   synchronize sensor
   WaitForData
   |> testHookMailbox.PostAndReply
-  |> (should (equalWithin 0.001) 200.0)
+  |> (should (equalWithin 0.001) 300.0)
 
   let activationFunctions : ActivationFunctions =
     Map.empty
@@ -708,7 +710,7 @@ let ``RemoveOutboundConnection mutation should remove some neuron connection ran
     |> Map.add outputHookId testHook
 
   let neuronId = neuronTwo |> fst
-  let initialNumberOfNeuronConnections = 2
+  let initialNumberOfNeuronConnections = 3
   let nodeRecords =
     let initialNodeRecords =
       Map.empty
@@ -719,7 +721,7 @@ let ``RemoveOutboundConnection mutation should remove some neuron connection ran
       |> constructNodeRecords
     initialNodeRecords
     |> Map.find neuronId
-    |> (fun neuronRecord -> neuronRecord.InboundConnections |> Seq.length |> should equal 2)
+    |> (fun neuronRecord -> neuronRecord.InboundConnections |> Seq.length |> should equal initialNumberOfNeuronConnections)
     let mutations = [RemoveOutboundConnection]
     {
       Mutations = mutations
@@ -733,7 +735,7 @@ let ``RemoveOutboundConnection mutation should remove some neuron connection ran
 
   nodeRecords
   |> Map.find neuronId
-  |> (fun neuronRecord -> neuronRecord.InboundConnections |> Seq.length |> should equal 1)
+  |> (fun neuronRecord -> neuronRecord.InboundConnections |> Seq.length |> should equal 2)
 
   [
     sensor
@@ -756,7 +758,7 @@ let ``RemoveOutboundConnection mutation should remove some neuron connection ran
   neuralNetwork |> synchronizeNN
   WaitForData
   |> testHookMailbox.PostAndReply
-  |> (should (equalWithin 0.001) 100.0)
+  |> (should (equalWithin 0.001) 200.0)
 
   neuralNetwork |> killNeuralNetwork
 

--- a/NeuralFish.Tests/Mutations.fs
+++ b/NeuralFish.Tests/Mutations.fs
@@ -391,7 +391,7 @@ let ``RemoveSensorLink mutation should remove a sensor connection randomly in th
   neuralNetwork |> synchronizeNN
   WaitForData
   |> testHookMailbox.PostAndReply
-  |> (should be (greaterThan 0.0))
+  |> (should be (lessThan 100.0))
 
   neuralNetwork |> killNeuralNetwork
 

--- a/NeuralFish.Tests/Mutations.fs
+++ b/NeuralFish.Tests/Mutations.fs
@@ -210,6 +210,7 @@ let ``ResetWeights mutation should mutate the weights of all inbound connections
 
       neuronConnections
       |> Seq.head
+      |> (fun x -> x.Value)
     neuronConnection.Weight
     |> should (equalWithin 0.1) 20.0
 
@@ -260,6 +261,7 @@ let ``ResetWeights mutation should mutate the weights of all inbound connections
 
       neuron.InboundConnections
       |> Seq.head
+      |> (fun x -> x.Value)
     
     neuronConnection.Weight
     |> should not' (equal 20.0)
@@ -280,3 +282,118 @@ let ``ResetWeights mutation should mutate the weights of all inbound connections
   neuralNetwork |> killNeuralNetwork
 
   Die |> testHookMailbox.PostAndReply
+
+[<Fact>]
+let ``RemoveSensorLink mutation should remove a sensor connection randomly in the neural network`` () =
+  //Test setup
+  let (testHook, testHookMailbox) = getTestHook ()
+  let getNodeId = getNumberGenerator()
+  let actuatorId = getNodeId()
+  let outputHookId = 9001
+  let activationFunctionId = 0
+  let activationFunction = id
+  let syncFunctionId = 0
+  let syncFunction =
+    let data =
+      [1.0; 1.0; 1.0; 1.0; 1.0; 1.0; 1.0; 1.0; 1.0; 1.0; 1.0]
+      |> List.toSeq
+    fakeDataGenerator([data])
+
+  //Create Neurons
+  let actuator =
+    let layer = 3
+    createActuator actuatorId layer testHook outputHookId
+    |> createNeuronInstance
+  let neuron =
+    let bias = 0.0
+    let nodeId = getNodeId()
+    let layer = 2
+    createNeuron nodeId layer activationFunction activationFunctionId bias NoLearning
+    |> createNeuronInstance
+
+  let sensor =
+    let id = getNodeId()
+    createSensor id syncFunction syncFunctionId 1
+    |> createNeuronInstance
+
+  //Connect Neurons
+  let weights =
+    [
+      20.0
+      20.0
+      20.0
+      20.0
+      20.0
+    ]
+  sensor |> connectSensorToNode neuron weights
+  neuron |> connectNodeToActuator actuator
+
+  //Synchronize and Assert!
+  synchronize sensor
+  WaitForData
+  |> testHookMailbox.PostAndReply
+  |> (should (equalWithin 0.1) 100.0)
+
+  let activationFunctions : ActivationFunctions =
+    Map.empty
+    |> Map.add activationFunctionId activationFunction
+  let syncFunctions =
+    Map.empty
+    |> Map.add syncFunctionId syncFunction
+  let outputHooks =
+    Map.empty
+    |> Map.add outputHookId testHook
+
+  let neuronId = neuron |> fst
+  let initialNumberOfNeuronConnections = weights |> List.length
+  let nodeRecords =
+    let initialNodeRecords =
+      Map.empty
+      |> addNeuronToMap actuator
+      |> addNeuronToMap neuron
+      |> addNeuronToMap sensor
+      |> constructNodeRecords
+    initialNodeRecords
+    |> Map.find neuronId
+    |> (fun neuronRecord -> neuronRecord.InboundConnections |> Seq.length |> should equal initialNumberOfNeuronConnections)
+    let mutations = [RemoveSensorLink]
+    {
+      Mutations = mutations
+      ActivationFunctionIds = [activationFunctionId]
+      SyncFunctionIds = [syncFunctionId]
+      OutputHookFunctionIds = [outputHookId]
+      LearningAlgorithm = NoLearning
+      InfoLog = defaultInfoLog
+      NodeRecords = initialNodeRecords
+    } |> mutateNeuralNetwork
+
+  nodeRecords
+  |> Map.find neuronId
+  |> (fun neuronRecord -> neuronRecord.InboundConnections |> Seq.length |> should be (lessThan initialNumberOfNeuronConnections))
+
+  [
+    sensor
+    neuron
+    actuator
+  ]
+  |> Map.ofList
+  |> killNeuralNetwork
+
+  let neuralNetwork =
+   {
+     ActivationFunctions = activationFunctions
+     SyncFunctions = syncFunctions
+     OutputHooks = outputHooks
+     NodeRecords = nodeRecords
+     InfoLog = defaultInfoLog
+   } |> constructNeuralNetwork
+
+  neuralNetwork |> synchronizeNN
+  WaitForData
+  |> testHookMailbox.PostAndReply
+  |> (should be (greaterThan 0.0))
+
+  neuralNetwork |> killNeuralNetwork
+
+  Die |> testHookMailbox.PostAndReply
+

--- a/NeuralFish.Tests/NeuralFish.Tests.fs
+++ b/NeuralFish.Tests/NeuralFish.Tests.fs
@@ -310,17 +310,17 @@ let ``Should be able to handle recurrent neural network with three neurons`` () 
   synchronize sensor
   WaitForData
   |> testHookMailbox.PostAndReply
-  |> (should equal 44320.0)
+  |> (should equal 320.0)
 
   synchronize sensor
   WaitForData
   |> testHookMailbox.PostAndReply
-  |> (should equal 1810520.0)
+  |> (should equal 50520.0)
 
   synchronize sensor
   WaitForData
   |> testHookMailbox.PostAndReply
-  |> (should equal 54734520.0)
+  |> (should equal 1934520.0)
 
   [
     sensor

--- a/NeuralFish.Tests/TestHelper.fs
+++ b/NeuralFish.Tests/TestHelper.fs
@@ -4,7 +4,8 @@ open NeuralFish.Core
 open NeuralFish.Cortex
 
 let createNeuronInstance = createNeuronInstance defaultInfoLog
-let createCortex = createCortex defaultInfoLog
+let defaultThinkTimeout = 500
+let createCortex = createCortex defaultThinkTimeout defaultInfoLog
 
 type GeneratorMsg =
   | GetData of AsyncReplyChannel<float seq>

--- a/NeuralFish/Cortex.fs
+++ b/NeuralFish/Cortex.fs
@@ -24,9 +24,8 @@ let createCortex thinkTimeout infoLog liveNeurons : CortexInstance =
       if timeIsUp then
         false
       else
-      //200 milliseconds of sleep seems plenty while waiting on the NN
       //TODO make this configurable
-        System.Threading.Thread.Sleep(200)
+        System.Threading.Thread.Sleep(50)
         waitOnAcutuators stopwatch neuralNetworkToWaitOn
     else
       true

--- a/NeuralFish/Cortex.fs
+++ b/NeuralFish/Cortex.fs
@@ -65,8 +65,8 @@ let createCortex thinkTimeout infoLog liveNeurons : CortexInstance =
             "Cortex - Starting think cycle" |> infoLog
             liveNeurons |> synchronizeNN
             //Sleep to give the NN a chance to process initial messages
-            //TODO Think of a better way to handle this intermittent startup
-            System.Threading.Thread.Sleep(200)
+            //TODO synchronize should post back after finishing
+            System.Threading.Thread.Sleep(100)
             "Cortex - Waiting on Neural Network to finish" |> infoLog
             stopwatch.Restart()
             let shouldActivateActuators = liveNeurons |> waitOnAcutuators stopwatch

--- a/NeuralFish/Cortex.fs
+++ b/NeuralFish/Cortex.fs
@@ -5,8 +5,8 @@ open NeuralFish.Exceptions
 open NeuralFish.Core
 open NeuralFish.Exporter
 
-let createCortex infoLog liveNeurons : CortexInstance =
-  let rec waitOnAcutuators neuralNetworkToWaitOn =
+let createCortex thinkTimeout infoLog liveNeurons : CortexInstance =
+  let rec waitOnAcutuators (stopwatch : System.Diagnostics.Stopwatch) neuralNetworkToWaitOn =
     let checkIfActuatorsAreReady (neuralNetwork : NeuralNetwork) =
       //returns true if active
       let actuatorIsActive (neuron : NeuronInstance) =
@@ -20,33 +20,39 @@ let createCortex infoLog liveNeurons : CortexInstance =
       neuralNetwork
       |> Map.exists(fun i (_,neuron) -> neuron |> checkIfNeuronIsBusy || not <| actuatorIsActive neuron  )
     if neuralNetworkToWaitOn |> checkIfActuatorsAreReady then
+      let timeIsUp = System.BitConverter.DoubleToInt64Bits(stopwatch.Elapsed.TotalMilliseconds) >= (int64 thinkTimeout)
+      if timeIsUp then
+        false
+      else
       //200 milliseconds of sleep seems plenty while waiting on the NN
       //TODO make this configurable
-      System.Threading.Thread.Sleep(200)
-      waitOnAcutuators neuralNetworkToWaitOn
+        System.Threading.Thread.Sleep(200)
+        waitOnAcutuators stopwatch neuralNetworkToWaitOn
     else
-      ()
+      true
 
   let registerCortex (neuralNetwork : NeuralNetwork) cortex =
-    let sendCortexToActuatorAsync _ (_, neuronInstance : NeuronInstance) =
+    let sendCortexToActuatorAsync (neuronInstance : NeuronInstance) =
       (fun r -> RegisterCortex (cortex,r)) |> neuronInstance.PostAndAsyncReply
     neuralNetwork
-    |> Map.map sendCortexToActuatorAsync
-    |> Map.toArray
-    |> Array.Parallel.map snd
+    |> Seq.map (fun keyValue -> keyValue.Value |> snd |> sendCortexToActuatorAsync)
+    |> Seq.toArray
     |> Async.Parallel
     |> ignore
     cortex
   let resetNeuralNetwork (neuralNetwork : NeuralNetwork) cortex =
+    let resetNeuron (neuronInstance : NeuronInstance) =
+      ResetNeuron |> neuronInstance.PostAndReply
     neuralNetwork
-    |> Map.iter (fun _ (_, neuronInstance : NeuronInstance) -> ResetNeuron |> neuronInstance.PostAndReply )
-
-    neuralNetwork
-    |> Map.iter(fun _ (_, neuronInstance : NeuronInstance) -> SendRecurrentSignals |> neuronInstance.PostAndReply)
-
+    |> Seq.iter (fun keyValue -> keyValue.Value |> snd |> resetNeuron)
     cortex
 
+  let sendRecurrentSignals neuralNetwork cortex =
+    neuralNetwork
+    |> Map.iter(fun _ (_, neuronInstance : NeuronInstance) -> SendRecurrentSignals |> neuronInstance.PostAndReply)
+    cortex
 
+  let stopwatch = System.Diagnostics.Stopwatch()
   CortexInstance.Start(fun inbox ->
     let rec loop liveNeurons =
       async {
@@ -63,11 +69,17 @@ let createCortex infoLog liveNeurons : CortexInstance =
             //TODO Think of a better way to handle this intermittent startup
             System.Threading.Thread.Sleep(200)
             "Cortex - Waiting on Neural Network to finish" |> infoLog
-            liveNeurons |> waitOnAcutuators
-            "Cortex - Think cycle finished. Activating Actuators" |> infoLog
-            liveNeurons |> activateActuators
-            "Cortex - Actuators Activated" |> infoLog
-            replyChannel.Reply ()
+            stopwatch.Restart()
+            let shouldActivateActuators = liveNeurons |> waitOnAcutuators stopwatch
+            stopwatch.Stop()
+            if shouldActivateActuators then
+              "Cortex - Think cycle finished. Activating Actuators" |> infoLog
+              liveNeurons |> activateActuators
+              "Cortex - Actuators Activated" |> infoLog
+              ThinkCycleFinished |> replyChannel.Reply
+            else
+              resetNeuralNetwork liveNeurons inbox |> ignore
+              ThinkCycleIncomplete |> replyChannel.Reply
             return! loop liveNeurons
           | KillCortex replyChannel ->
             "Cortex - Gathering Updated Node Records" |> infoLog
@@ -82,4 +94,5 @@ let createCortex infoLog liveNeurons : CortexInstance =
   )
   |> registerCortex liveNeurons
   |> resetNeuralNetwork liveNeurons
+  |> sendRecurrentSignals liveNeurons
   |> (fun x -> x.Error.Add(fun x -> sprintf "%A" x |> infoLog); x)

--- a/NeuralFish/EvolutionChamber.fs
+++ b/NeuralFish/EvolutionChamber.fs
@@ -642,16 +642,18 @@ let mutateNeuralNetwork (mutationProperties : MutationProperties) : NodeRecords 
         | RemoveInboundConnection ->
           let eligibleRecords =
             let doesRecordHaveANeuronConnection (_,nodeRecord) =
-              let connections =
-                nodeRecord.InboundConnections
-                |> Map.filter (fun _ connection -> processingNodeRecords |> Map.find connection.NodeId |> (fun x -> x.NodeType) |> isRecordASensor |> not)
-              if connections |> Map.isEmpty then
-                None
-              else
-                Some (nodeRecord, connections)
+              match nodeRecord.NodeType with
+              | NodeRecordType.Neuron ->
+                let connections =
+                  nodeRecord.InboundConnections
+                  |> Map.filter (fun _ connection -> processingNodeRecords |> Map.find connection.NodeId |> (fun x -> x.NodeType) |> isRecordASensor |> not)
+                if connections |> Map.isEmpty then
+                  None
+                else
+                  Some (nodeRecord, connections)
+              | _ -> None
             processingNodeRecords
             |> Map.toSeq
-            |> Seq.filter (fun (_,record) -> record.NodeType = NodeRecordType.Neuron)
             |> Seq.map doesRecordHaveANeuronConnection
             |> Seq.filter (fun x -> x.IsSome)
           if eligibleRecords |> Seq.isEmpty then

--- a/NeuralFish/EvolutionChamber.fs
+++ b/NeuralFish/EvolutionChamber.fs
@@ -508,7 +508,29 @@ let mutateNeuralNetwork (mutationProperties : MutationProperties) : NodeRecords 
             |> Map.add mutatedNeuron.NodeId mutatedNeuron
             |> Map.toSeq
             |> addUpdatedOutboundConnections processingNodeRecords
-       // | RemoveActuatorLink ->
+        | RemoveActuatorLink ->
+          let _, randomActuator =
+            processingNodeRecords
+            |> Map.filter(fun _ record -> record.NodeType = NodeRecordType.Actuator)
+            |> selectRandomNode
+          let numberOfActuatorInboundConnections =
+            randomActuator.InboundConnections
+            |> Seq.length
+          if numberOfActuatorInboundConnections = 1 then
+            mutateRandomly()
+          else
+            let updatedInboundConnections =
+              let randomIndex = random.Next numberOfActuatorInboundConnections
+              let randomConnectionKey =
+                randomActuator.InboundConnections
+                |> Seq.item randomIndex
+                |> (fun x -> x.Key)
+              randomActuator.InboundConnections
+              |> Map.remove randomConnectionKey
+            let updatedActuator =
+              { randomActuator with InboundConnections = updatedInboundConnections }
+            processingNodeRecords
+            |> Map.add updatedActuator.NodeId updatedActuator
         | AddSensor ->
           let sensorRecords =
             processingNodeRecords

--- a/NeuralFish/EvolutionChamber.fs
+++ b/NeuralFish/EvolutionChamber.fs
@@ -217,7 +217,28 @@ let mutateNeuralNetwork (mutationProperties : MutationProperties) : NodeRecords 
 
           processingNodeRecords
           |> Map.add mutatedNeuron.NodeId mutatedNeuron
-       // | ResetWeights ->
+        | ResetWeights ->
+          let _, neuronToMutateWeights =
+            processingNodeRecords
+            |> Map.filter(fun _ x -> x.NodeType = NodeRecordType.Neuron)
+            |> selectRandomNode
+          let mutatedNeuron =
+            let newInboundConnections =
+              let resetWeight (inactiveConnection : InactiveNeuronConnection) =
+                let newWeight =
+                  let pi = System.Math.PI
+                  let maxValue = pi/2.0
+                  let minValue = -1.0 * pi/2.0
+                  getRandomDoubleBetween minValue maxValue
+                { inactiveConnection with
+                    Weight = newWeight
+                }
+              neuronToMutateWeights.InboundConnections
+              |> Seq.map resetWeight
+            { neuronToMutateWeights with InboundConnections = newInboundConnections }
+
+          processingNodeRecords
+          |> Map.add mutatedNeuron.NodeId mutatedNeuron
 //        | MutateActivationFunction ->
 //          let neuronToMutateAF =
 //            nodeRecords

--- a/NeuralFish/Exporter.fs
+++ b/NeuralFish/Exporter.fs
@@ -64,7 +64,7 @@ let constructNeuralNetwork (neuralNetProperties : ConstructNeuralNetworkProperti
 
         sprintf "%A has inbound connections %A" targetNodeId node.InboundConnections |> infoLog
         node.InboundConnections
-        |> Seq.iter (fun inboundConnection -> findNeuronAndAddToOutboundConnections inboundConnection node.NodeId)
+        |> Map.iter (fun _ inboundConnection -> findNeuronAndAddToOutboundConnections inboundConnection node.NodeId)
       nodeRecords
       |> Map.find targetNodeId
       |> processRecordConnections

--- a/NeuralFish/NeuralFish.fs
+++ b/NeuralFish/NeuralFish.fs
@@ -43,6 +43,7 @@ let activateActuators (neuralNetwork : NeuralNetwork) =
   |> Array.Parallel.iter activateActuator
 
 let synchronize (_, (_,sensor : NeuronInstance)) =
+  //TODO have this timeout and return confirmation
   Sync |> sensor.Post
 
 let synchronizeNN (neuralNetwork : NeuralNetwork) =
@@ -199,20 +200,21 @@ let createNeuronInstance infoLog neuronType =
                      (outboundConnections : NeuronConnections)
                        (maximumVectorLength : int)
                          (maybeCortex : bool option)
-                           (recurrentOutboundConnections : RecurrentNeuronConnections) =
+                           (recurrentOutboundConnections : RecurrentNeuronConnections) 
+                             (overflowBarrier : AxonHillockBarrier) =
       async {
         let! someMsg = inbox.TryReceive 250
         match someMsg with
         | None ->
-          return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+          return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections overflowBarrier
         | Some msg ->
           match msg with
           | Sync ->
             match neuronType with
             | Neuron _ ->
-              return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+              return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections overflowBarrier
             | Actuator _ ->
-              return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+              return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections overflowBarrier
             | Sensor props ->
               let inflateData expectedVectorLength (dataStream : NeuronOutput seq) =
                 let inflatedData =
@@ -252,7 +254,7 @@ let createNeuronInstance infoLog neuronType =
               else
                 let orderedConnections = outboundConnections |> Seq.sortBy(fun connection -> connection.ConnectionOrder)
                 processSensorSync dataStream orderedConnections
-              return! loop barrier inboundConnections outboundConnections newMaximumVectorLength maybeCortex recurrentOutboundConnections
+              return! loop barrier inboundConnections outboundConnections newMaximumVectorLength maybeCortex recurrentOutboundConnections overflowBarrier
           | ReceiveInput (neuronConnectionId, package, neuronActivationOption) ->
             let processLearning learningAlgorithm (weightedSynapses : WeightedSynapses) (neuronOutput : NeuronOutput) : InboundNeuronConnections =
               let processLearningForConnection ((synapse,inboundConnection) : WeightedSynapse) =
@@ -266,9 +268,18 @@ let createNeuronInstance infoLog neuronType =
               weightedSynapses
               |> Seq.map processLearningForConnection
 
-            let updatedBarrier : IncomingSynapses =
-              barrier
-              |> Map.add neuronConnectionId package
+            let updatedOverflowBarrier, (updatedBarrier : AxonHillockBarrier) =
+              if barrier |> Map.containsKey neuronConnectionId then
+                let updatedOverflowBarrier =
+                  overflowBarrier
+                  |> Map.add neuronConnectionId package
+                updatedOverflowBarrier, barrier
+              else
+                let updatedBarrier : AxonHillockBarrier =
+                  barrier
+                  |> Map.add neuronConnectionId package
+                overflowBarrier, updatedBarrier
+              
             let activateIfBarrierIsFull, activateIfNeuronHasOneConnection =
               match neuronActivationOption with
               | ActivateIfBarrierIsFull -> true, false
@@ -295,27 +306,25 @@ let createNeuronInstance infoLog neuronType =
                 let neuronOutput = props |> activateNeuron weightedSynapses outboundConnections
                 let updatedInboundConnections =
                   processLearning props.Record.NeuronLearningAlgorithm weightedSynapses neuronOutput
-                return! loop Map.empty updatedInboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+                return! loop updatedOverflowBarrier updatedInboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections Map.empty
               else
                 sprintf "Barrier not satisfied for Neuron %A. Received %A from %A" props.Record.NodeId package neuronConnectionId |> infoLog
-                return! loop updatedBarrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+                return! loop updatedBarrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections updatedOverflowBarrier
             | Actuator props ->
               if (activateIfBarrierIsFull && updatedBarrier |> isBarrierSatisifed inboundConnections) then
                 match maybeCortex with
                 | None ->
                   sprintf "Barrier is satisifed for Actuator %A" props.Record.NodeId |> infoLog
                   props |> activateActuator updatedBarrier
-                  return! loop Map.empty inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+                  return! loop updatedOverflowBarrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections Map.empty
                 | Some _ ->
                   sprintf "Barrier is satisifed for Actuator %A. Not activating due to registered cortex. Waiting for a signal from the cortex" props.Record.NodeId |> infoLog
                   let readyToActivate = Some true
-                  return! loop updatedBarrier inboundConnections outboundConnections maximumVectorLength readyToActivate recurrentOutboundConnections
+                  return! loop updatedBarrier inboundConnections outboundConnections maximumVectorLength readyToActivate recurrentOutboundConnections updatedOverflowBarrier
               else
                 sprintf "Node %A not activated. Received %A from %A" nodeId package neuronConnectionId |> infoLog
-                return! loop updatedBarrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
-            | Sensor _ ->
-              //Sensors use the sync msg
-              return! loop Map.empty inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+                return! loop updatedBarrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections updatedOverflowBarrier
+            | Sensor _ -> raise <| System.Exception("Sensor should not receive input")
           | NeuronActions.AddOutboundConnection ((toNodeType,toNode,outboundLayer,partialOutboundConnection),replyChannel) ->
               let neuronConnectionId = System.Guid.NewGuid()
               let connectionOrder = 
@@ -373,14 +382,14 @@ let createNeuronInstance infoLog neuronType =
 
               sprintf "Node %A is adding Node %A as an outbound connection %A with weight %A" neuronType partialOutboundConnection.ToNodeId neuronConnectionId partialOutboundConnection.InitialWeight
               |> infoLog
-              return! loop barrier inboundConnections updatedOutboundConnections maximumVectorLength maybeCortex updatedRecurrentOutboundConnections
+              return! loop barrier inboundConnections updatedOutboundConnections maximumVectorLength maybeCortex updatedRecurrentOutboundConnections overflowBarrier
             | NeuronActions.AddInboundConnection (inboundConnection, replyChannel) ->
               let updatedInboundConnections =
                 Seq.append inboundConnections [inboundConnection]
               replyChannel.Reply()
               sprintf "Node %A Added inbound neuron %A connection %A" nodeId inboundConnection.FromNodeId inboundConnection.NeuronConnectionId
               |> infoLog
-              return! loop barrier updatedInboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+              return! loop barrier updatedInboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections overflowBarrier
             | GetNodeRecord replyChannel ->
               async {
                 let inactiveConnections : NodeRecordConnections =
@@ -411,24 +420,23 @@ let createNeuronInstance infoLog neuronType =
                 let nodeRecordWithConnections = { nodeRecord with InboundConnections = inactiveConnections}
                 nodeRecordWithConnections |> replyChannel.Reply
               } |> Async.Start |> ignore
-              return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+              return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections overflowBarrier
             | Die replyChannel ->
               replyChannel.Reply()
-              ()
             | RegisterCortex (_,replyChannel) ->
               match neuronType with
               | Actuator _ ->
                 let someReadyToActivate = Some false
                 replyChannel.Reply ()
-                return! loop barrier inboundConnections outboundConnections maximumVectorLength someReadyToActivate recurrentOutboundConnections
+                return! loop barrier inboundConnections outboundConnections maximumVectorLength someReadyToActivate recurrentOutboundConnections overflowBarrier
               | _ ->
                 replyChannel.Reply ()
-                return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+                return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections overflowBarrier
             | ActivateActuator replyChannel ->
               match maybeCortex with
               | None ->
                 replyChannel.Reply()
-                return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+                return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections overflowBarrier
               | Some readyToActivate ->
                 if readyToActivate then
                   match neuronType with
@@ -437,35 +445,35 @@ let createNeuronInstance infoLog neuronType =
                     props |> activateActuator barrier
                     replyChannel.Reply ()
                     let notReadyToActivate = Some false
-                    return! loop Map.empty inboundConnections outboundConnections maximumVectorLength notReadyToActivate recurrentOutboundConnections
+                    return! loop overflowBarrier inboundConnections outboundConnections maximumVectorLength notReadyToActivate recurrentOutboundConnections Map.empty
                   | _ ->
                     replyChannel.Reply ()
-                    return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+                    return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections overflowBarrier
                 else
                   replyChannel.Reply ()
-                  return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+                  return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections overflowBarrier
             | CheckActuatorStatus replyChannel ->
               match maybeCortex with
               | None ->
                 true |> replyChannel.Reply
               | Some readyToActivate ->
                 readyToActivate |> replyChannel.Reply
-              return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+              return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections overflowBarrier
             | ResetNeuron replyChannel ->
               let updatedInboundConnections =
                 inboundConnections
                 |> Seq.map(fun connection -> { connection with Weight = connection.InitialWeight})
               replyChannel.Reply()
-              return! loop Map.empty updatedInboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+              return! loop Map.empty updatedInboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections overflowBarrier
             | SendRecurrentSignals replyChannel ->
               let sendRecurrentSignalFromConnection (connection : NeuronConnection) =
                 (connection.NodeId, connection.Neuron) |> sendRecurrentSignal ActivateIfNeuronHasOneConnection connection.NeuronConnectionId
               recurrentOutboundConnections
               |> Seq.iter sendRecurrentSignalFromConnection
               replyChannel.Reply ()
-              return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections
+              return! loop barrier inboundConnections outboundConnections maximumVectorLength maybeCortex recurrentOutboundConnections overflowBarrier
       }
-    loop Map.empty Seq.empty Seq.empty 0 None Seq.empty
+    loop Map.empty Seq.empty Seq.empty 0 None Seq.empty Map.empty
   )
 
   //Add exception logging

--- a/NeuralFish/NeuralFish.fs
+++ b/NeuralFish/NeuralFish.fs
@@ -16,9 +16,8 @@ let killNeuralNetwork (liveNeurons : NeuralNetwork) =
       neuralNetwork
       |> Map.exists(fun i (nodeRecordId,neuron) -> neuron.CurrentQueueLength <> 0)
     if neuralNetworkToWaitOn |> checkIfNeuralNetworkIsActive then
-      //200 milliseconds of sleep seems plenty while waiting on the NN
       //TODO make this configurable
-      System.Threading.Thread.Sleep(200)
+      System.Threading.Thread.Sleep(50)
       waitOnNeuralNetwork neuralNetworkToWaitOn
     else
       neuralNetworkToWaitOn

--- a/NeuralFish/NeuralFish.fs
+++ b/NeuralFish/NeuralFish.fs
@@ -70,7 +70,7 @@ let createNeuron id layer activationFunction activationFunctionId bias learningA
      NodeId = id
      Layer = layer
      NodeType = NodeRecordType.Neuron
-     InboundConnections = Seq.empty
+     InboundConnections = Map.empty
      Bias = Some bias
      ActivationFunctionId = Some activationFunctionId
      SyncFunctionId = None
@@ -90,7 +90,7 @@ let createSensor id syncFunction syncFunctionId maximumVectorLength =
     NodeId = id
     Layer = 0
     NodeType = NodeRecordType.Sensor 0
-    InboundConnections = Seq.empty
+    InboundConnections = Map.empty
     Bias = None
     ActivationFunctionId = None
     SyncFunctionId = Some syncFunctionId
@@ -110,7 +110,7 @@ let createActuator id layer outputHook outputHookId =
     NodeId = id
     Layer = layer
     NodeType = NodeRecordType.Actuator
-    InboundConnections = Seq.empty
+    InboundConnections = Map.empty
     Bias = None
     ActivationFunctionId = None
     SyncFunctionId = None
@@ -384,14 +384,15 @@ let createNeuronInstance infoLog neuronType =
             | GetNodeRecord replyChannel ->
               async {
                 let inactiveConnections : NodeRecordConnections =
-                  let createInactiveConnection (inboundNeuronConnection : InboundNeuronConnection) : InactiveNeuronConnection =
-                    {
+                  let createInactiveConnection (inboundNeuronConnection : InboundNeuronConnection) : NeuronConnectionId*InactiveNeuronConnection =
+                    inboundNeuronConnection.NeuronConnectionId, {
                       NodeId = inboundNeuronConnection.FromNodeId
                       Weight = inboundNeuronConnection.InitialWeight
                       ConnectionOrder = inboundNeuronConnection.ConnectionOrder
                     }
                   inboundConnections
                   |> Seq.map createInactiveConnection
+                  |> Map.ofSeq
                 let nodeRecord =
                   match neuronType with
                   | Neuron props -> props.Record

--- a/NeuralFish/NeuralFish_dev.fsx
+++ b/NeuralFish/NeuralFish_dev.fsx
@@ -1,5 +1,4 @@
 #I __SOURCE_DIRECTORY__
-#I "../NeuralFish.Tests"
 
 #load "Types.fs"
 #load "Exceptions.fs"
@@ -7,6 +6,8 @@
 #load "Exporter.fs"
 #load "Cortex.fs"
 #load "EvolutionChamber.fs"
+
+#I "../NeuralFish.Tests"
 #load "TestHelper.fs"
 
 open NeuralFish.Types

--- a/NeuralFish/Types.fs
+++ b/NeuralFish/Types.fs
@@ -48,7 +48,7 @@ type AxonHillockBarrier = Map<NeuronConnectionId, Synapse>
 
 type IncomingSynapses = Map<NeuronConnectionId, Synapse>
 
-type InactiveNeuronConnection = 
+type InactiveNeuronConnection =
   {
     NodeId : NeuronId
     Weight : Weight
@@ -165,7 +165,7 @@ type NeuronConnection =
 type NeuronConnections = seq<NeuronConnection>
 type RecurrentNeuronConnections = NeuronConnections
 
-type InboundNeuronConnections = seq<InboundNeuronConnection> 
+type InboundNeuronConnections = seq<InboundNeuronConnection>
 
 type NeuralNetwork = Map<NeuronId, NeuronLayerId*NeuronInstance>
 
@@ -218,7 +218,7 @@ type Mutation =
   | AddSensorLink
   | AddActuatorLink
   | RemoveSensorLink
-  // | RemoveActuatorLink
+  | RemoveActuatorLink
   | AddSensor
   | AddActuator
   // | RemoveInboundConnection

--- a/NeuralFish/Types.fs
+++ b/NeuralFish/Types.fs
@@ -172,6 +172,7 @@ type RecurrentNeuronConnections = NeuronConnections
 type InboundNeuronConnections = seq<InboundNeuronConnection>
 
 type NeuralNetwork = Map<NeuronId, NeuronLayerId*NeuronInstance>
+type NeuralNetworkSeq = seq<NeuronId*(NeuronLayerId*NeuronInstance)>
 
 type Score = float
 

--- a/NeuralFish/Types.fs
+++ b/NeuralFish/Types.fs
@@ -97,9 +97,13 @@ type ConstructNeuralNetworkProperties =
     InfoLog : InfoLogFunction
   }
 
+type ThinkCycleState =
+  | ThinkCycleFinished
+  | ThinkCycleIncomplete
+
 type CortexMessage =
-    | ThinkAndAct of AsyncReplyChannel<unit>
-    | KillCortex of AsyncReplyChannel<NodeRecords>
+  | ThinkAndAct of AsyncReplyChannel<ThinkCycleState>
+  | KillCortex of AsyncReplyChannel<NodeRecords>
 
 type CortexInstance = MailboxProcessor<CortexMessage>
 
@@ -194,7 +198,7 @@ type ThinkCycleOption =
   | EndThinkCycle
   | ContinueThinkCycle
 
-type LiveFitnessFunction = NodeRecordsId -> Score*ThinkCycleOption
+type LiveFitnessFunction = NodeRecordsId -> ThinkCycleState -> Score*ThinkCycleOption
 
 type GenerationRecords = Map<NodeRecordsId, NodeRecords>
 
@@ -265,6 +269,7 @@ type EvolutionProperties =
     DividePopulationBy : int
     InfoLog : InfoLogFunction
     AsynchronousScoring : bool
+    ThinkTimeout : int
   }
 
 type DataGeneratorMsg<'T> =
@@ -324,4 +329,5 @@ type LiveEvolutionProperties =
     EndOfGenerationFunctionOption : EndOfGenerationFunction option
     BeforeGenerationFunctionOption : BeforeGenerationFunction option
     InfoLog : InfoLogFunction
+    ThinkTimeout : int
   }

--- a/NeuralFish/Types.fs
+++ b/NeuralFish/Types.fs
@@ -221,8 +221,8 @@ type Mutation =
   | RemoveActuatorLink
   | AddSensor
   | AddActuator
-  // | RemoveInboundConnection
-  // | RemoveOutboundConnection
+  | RemoveInboundConnection
+  | RemoveOutboundConnection
   // | RemoveNeuron
   // //Remove neuron then connect inputs to outputs
   // | DespliceOut

--- a/NeuralFish/Types.fs
+++ b/NeuralFish/Types.fs
@@ -209,12 +209,7 @@ type Mutation =
   | AddBias
   | RemoveBias
   | MutateWeights
-  // //Choose random neuron, perturb each weight with probability of
-  // //1/sqrt(# of weights)
-  // //Intensity chosen randomly between -pi/2 and pi/2
-  // | ResetWeights
-  // //Choose random neuron, reset all weights to random values
-  // // ranging between -pi/2 and pi/2
+  | ResetWeights
   | AddInboundConnection
   // //Choose a random neuron A, node B, and add a connection
   | AddOutboundConnection

--- a/NeuralFish/Types.fs
+++ b/NeuralFish/Types.fs
@@ -62,7 +62,7 @@ type NodeRecordType =
   | Sensor of NumberOfOutboundConnections
   | Actuator
 
-type NodeRecordConnections = seq<InactiveNeuronConnection>
+type NodeRecordConnections = Map<NeuronConnectionId,InactiveNeuronConnection>
 
 type LearningRateCoefficient = float
 
@@ -211,14 +211,13 @@ type Mutation =
   | MutateWeights
   | ResetWeights
   | AddInboundConnection
-  // //Choose a random neuron A, node B, and add a connection
   | AddOutboundConnection
   | AddNeuron
   | AddNeuronOutSplice
   | AddNeuronInSplice
   | AddSensorLink
   | AddActuatorLink
-  // | RemoveSensorLink
+  | RemoveSensorLink
   // | RemoveActuatorLink
   | AddSensor
   | AddActuator


### PR DESCRIPTION
Adds the mutations

- RemoveSensorLink
- RemoveActuatorLink
- RemoveInboundConnection

Also adds self recovery if the neural network is synchronized by the cortex. This is controlled by a configurable timeout value

The above feature is to get around the Pruning mutations from causing a NN to be inoperable. This hides potential bugs in the system so It is extremely vital that more tests are written around the pieces of logic in NeuralFish.

I also attempted to speed up construction of large networks by changing the construction process to a parallel computation.